### PR TITLE
Improve UI and fix OpenAI 404

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,8 +6,8 @@ import {
 } from "@heroicons/react/24/outline";
 function HomePage() {
   return (
-    <div className="flex flex-col items-center justify-center h-screen px-2 text-white">
-      <h1 className="text-5xl font-bold mb-20">ChatGpt Clone</h1>
+    <div className="flex flex-col items-center justify-center h-screen px-2 text-white bg-gradient-to-b from-[#343541] to-[#202123]">
+      <h1 className="text-5xl font-bold mb-20">ChatGPT Clone</h1>
       <div className="flex space-x-2 text-center">
         <div>
           <div className="flex flex-col items-center justify-center mb-5">

--- a/components/ChatInput.tsx
+++ b/components/ChatInput.tsx
@@ -75,8 +75,7 @@ function ChatInput({ chatId }: Props) {
     <div className="bg-gray-700/50 text-gray-400 rounded-lg text-sm">
       <form onSubmit={sendMessage} className="p-5 space-x-5 flex">
         <input
-          className="bg-transparent focus:outline-none flex-1 
-          disabled:cursor-not-allowed disabled:text-gray-300"
+          className="bg-transparent flex-1 border border-gray-600 rounded focus:outline-none px-3 py-2 disabled:cursor-not-allowed disabled:text-gray-300"
           disabled={!session}
           type="text"
           value={prompt}
@@ -86,8 +85,7 @@ function ChatInput({ chatId }: Props) {
         <button
           disabled={!prompt || !session}
           type="submit"
-          className="bg-[#11A37F] hover:opacity-50 text-white font-bold 
-          px-4 py-2 rounded disabled:bg-gray-300 disabled:cursor-not-allowed"
+          className="bg-[#11A37F] hover:opacity-50 text-white font-bold px-4 py-2 rounded disabled:bg-gray-300 disabled:cursor-not-allowed"
         >
           <PaperAirplaneIcon className="h-4 w-4 -rotate-45" />
         </button>

--- a/components/ChatRow.tsx
+++ b/components/ChatRow.tsx
@@ -34,7 +34,7 @@ function ChatRow({ id }: Props) {
   return (
     <Link
       href={`/chat/${id}`}
-      className={`chatRow justify-center ${active && "bg-gray-700/50"}`}
+      className={`chatRow justify-center ${active ? "bg-gray-700" : ""}`}
     >
       <ChatBubbleLeftIcon className="h-5 w-5" />
       <p className="flex-1 hidden md:inline-flex truncate">

--- a/components/Message.tsx
+++ b/components/Message.tsx
@@ -8,10 +8,18 @@ function Message({ message }: Props) {
   const isChatGPT = message.user.name === "ChatGPT";
 
   return (
-    <div className={`py-5 text-white ${isChatGPT && "bg-[#434654]"}`}>
+    <div
+      className={`py-5 text-white ${
+        isChatGPT ? "bg-gray-700" : "bg-gray-600/50"
+      }`}
+    >
       <div className="flex space-x-5 px-10 max-w-2xl mx-auto">
-        <img src={message.user.avatar} alt="user-image" className="h-8 w-8" />
-        <p className="pt-1 text-sm">{message.text}</p>
+        <img
+          src={message.user.avatar}
+          alt="user image"
+          className="h-8 w-8 rounded-md"
+        />
+        <p className="pt-1 text-sm leading-relaxed">{message.text}</p>
       </div>
     </div>
   );

--- a/lib/queryAPI.ts
+++ b/lib/queryAPI.ts
@@ -7,8 +7,22 @@ const configuration = new Configuration({
 const openai = new OpenAIApi(configuration);
 
 const query = async (prompt: string, chatId: string, model: string) => {
-  const res = await openai
-    .createCompletion({
+  try {
+    if (model.startsWith("gpt-")) {
+      const res = await openai.createChatCompletion({
+        model,
+        messages: [{ role: "user", content: prompt }],
+        temperature: 0.9,
+        top_p: 1,
+        max_tokens: 1000,
+        frequency_penalty: 0,
+        presence_penalty: 0,
+      });
+
+      return res.data.choices[0].message?.content?.trim();
+    }
+
+    const res = await openai.createCompletion({
       model,
       prompt,
       temperature: 0.9,
@@ -16,13 +30,12 @@ const query = async (prompt: string, chatId: string, model: string) => {
       max_tokens: 1000,
       frequency_penalty: 0,
       presence_penalty: 0,
-    })
-    .then((res) => res.data.choices[0].text)
-    .catch(
-      (err) =>
-        `ChatGPT was unable to find an answer for that! (Error: ${err.message})`
-    );
-  return res;
+    });
+
+    return res.data.choices[0].text?.trim();
+  } catch (err: any) {
+    return `ChatGPT was unable to find an answer for that! (Error: ${err.message})`;
+  }
 };
 
 export default query;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,7 +4,7 @@
 
 @layer components {
   .infoText {
-    @apply p-4 bg-[#3e3f4b] rounded-lg max-w-[300px];
+    @apply p-4 bg-gray-700/50 rounded-lg max-w-[300px] text-sm;
   }
 
   .chatRow {


### PR DESCRIPTION
## Summary
- improve openAI query to support `gpt-*` models via chat completion
- refine message and chat input styling
- tweak sidebar chat row highlight
- polish landing page style
- adjust default `infoText` styling

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fbb6aef408333b1cb0d8827df18b5