### PR TITLE
Fix chat completions with fetch

### DIFF
--- a/lib/openaiService.ts
+++ b/lib/openaiService.ts
@@ -1,5 +1,7 @@
 import { Configuration, OpenAIApi, ChatCompletionRequestMessage } from "openai";
 
+const CHAT_ENDPOINT = "https://api.openai.com/v1/chat/completions";
+
 const apiKey = process.env.OPENAI_API_KEY;
 if (!apiKey) {
   throw new Error("OPENAI_API_KEY environment variable is missing");
@@ -12,12 +14,26 @@ export async function chatWithGPT(
   model: string = "gpt-3.5-turbo"
 ): Promise<string> {
   try {
-    const res = await openai.createChatCompletion({ model, messages });
-    return res.data.choices[0].message?.content?.trim() || "";
-  } catch (err: any) {
-    if (err.response?.status === 429) {
-      throw new Error("Rate limit exceeded. Please try again later.");
+    const res = await fetch(CHAT_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ model, messages }),
+    });
+
+    if (!res.ok) {
+      if (res.status === 429) {
+        throw new Error("Rate limit exceeded. Please try again later.");
+      }
+      const text = await res.text();
+      throw new Error(text || "OpenAI request failed");
     }
+
+    const data = await res.json();
+    return data.choices[0]?.message?.content?.trim() || "";
+  } catch (err: any) {
     throw new Error(err.message || "OpenAI request failed");
   }
 }


### PR DESCRIPTION
## Summary
- overhaul `chatWithGPT` to use direct HTTP requests following the OpenAI docs

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fc625e8848333869bfd87e4e8d06b